### PR TITLE
Update build.gradle

### DIFF
--- a/starter/app/build.gradle
+++ b/starter/app/build.gradle
@@ -63,8 +63,9 @@ dependencies {
 
     implementation 'com.squareup.picasso:picasso:2.5.2'
 
-    implementation "androidx.room:room-runtime:2.2.5"
-    kapt "androidx.room:room-compiler:2.2.5"
+    implementation("androidx.room:room-ktx:2.3.0-alpha01")
+    implementation "androidx.room:room-runtime:2.3.0-alpha01"
+    kapt "androidx.room:room-compiler:2.3.0-alpha01"
 
     implementation "android.arch.work:work-runtime-ktx:1.0.1"
 


### PR DESCRIPTION
Room creates an Error on compiling in my configuration - Error Message:
ANTLR Tool version 4.5.3 used for code generation does not match the current runtime version 4.7.1

It seems that Room is loading different Dependencies. This Issue was fixed here:
https://issuetracker.google.com/issues/150106190

Resource of my Infos ist thes therad:
https://stackoverflow.com/questions/60864940/antlr-tool-version-4-5-3-used-for-code-generation-does-not-match-the-current-run

Further Android Studios is complaining to add ktx to Room to make it working - Error Message:
/home/xxx/AndroidStudioProjects/Project/starter/app/build/tmp/kapt3/stubs/debug/com/udacity/asteroidradar/db/APODDao.java:23: error: To use Coroutine features, you must add `ktx` artifact from Room as a dependency. androidx.room:room-ktx:<version>

        Correct working Dependencies:
implementation("androidx.room:room-ktx:2.3.0-alpha01")
implementation "androidx.room:room-runtime:2.3.0-alpha01"
kapt "androidx.room:room-compiler:2.3.0-alpha01"

Please Implement
Thanks Tom